### PR TITLE
Upgrade to Serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["rustdt", "jsonrpc", "json-rpc", "rpc"]
 [dependencies]
 rustdt_util = "0.2.3"
 log = "0.3.6"
-serde = "0.9"
-serde_json = "0.9"
+serde = "1.0"
+serde_json = "1.0"
 futures = "0.1.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["rustdt", "jsonrpc", "json-rpc", "rpc"]
 [dependencies]
 rustdt_util = "0.2.3"
 log = "0.3.6"
-serde = "0.8"
-serde_json = "0.8"
+serde = "0.9"
+serde_json = "0.9"
 futures = "0.1.3"
 
 [dev-dependencies]

--- a/src/json_util.rs
+++ b/src/json_util.rs
@@ -134,7 +134,7 @@ impl<DE> SerdeJsonDeserializerHelper<DE> {
     }
 }
 
-impl<DE : serde::Deserializer> 
+impl<'de, DE : serde::Deserializer<'de>> 
     JsonDeserializerHelper<DE::Error> for SerdeJsonDeserializerHelper<DE> 
 {
     fn new_error(&self, error_message: &str) -> DE::Error {
@@ -174,13 +174,13 @@ pub mod test_util {
         serde_json::to_string(value).unwrap()
     }
     
-    pub fn from_json<T: Deserialize>(json: &str) -> T {
+    pub fn from_json<'de, T: Deserialize<'de>>(json: &'de str) -> T {
         serde_json::from_str(json).unwrap()
     }
 
     pub fn test_serde<T>(obj: &T) 
         -> (T, String)
-        where T : Serialize + Deserialize + PartialEq + Debug
+        where for<'de> T : Serialize + Deserialize<'de> + PartialEq + Debug
     {
         let json = to_json(obj);
         let reserialized : T = from_json(&json);
@@ -188,8 +188,8 @@ pub mod test_util {
         (reserialized, json)
     }
     
-    pub fn test_error_de<T>(json: &str, expected_err_contains: &str) 
-        where T : Deserialize + PartialEq + Debug
+    pub fn test_error_de<'de, T>(json: &'de str, expected_err_contains: &str) 
+        where T : Deserialize<'de> + PartialEq + Debug
     {
         let res = serde_json::from_str::<T>(json).unwrap_err();
         check_err_contains(res, expected_err_contains);
@@ -197,7 +197,7 @@ pub mod test_util {
     
     pub fn test_serde_expecting<T>(obj: &T, expected_value: &Value) 
         -> Value
-        where T : Serialize + Deserialize + PartialEq + Debug
+        where for<'de> T : Serialize + Deserialize<'de> + PartialEq + Debug
     {
         let json = test_serde(obj).1;
         

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -24,7 +24,7 @@ https://github.com/RustDT/rustdt-json_rpc/blob/master/tests/example.rs
 #![allow(non_camel_case_types)]
 
 #[macro_use] extern crate log;
-extern crate serde_json;
+#[macro_use] extern crate serde_json;
 extern crate serde;
 
 extern crate rustdt_util as util;
@@ -459,7 +459,7 @@ impl Endpoint {
     >(&self, id: Option<Id>, method_name: &str, params: PARAMS) 
         -> GResult<()> 
     {
-        let params_value = serde_json::to_value(&params);
+        let params_value = serde_json::to_value(&params)?;
         let params = jsonrpc_request::to_jsonrpc_params(params_value)?;
         
         let rpc_request = Request { id: id.clone(), method : method_name.into(), params : params };
@@ -593,12 +593,12 @@ mod tests_ {
         let request = Request::new(1, "sample_fn".to_string(), JsonObject::new());
         invoke_method(&mut request_handler, &request.method, request.params, 
             |result| 
-            check_request(result.unwrap(), ResponseResult::Error(error_JSON_RPC_InvalidParams(r#"missing field "x""#)))
+            check_request(result.unwrap(), ResponseResult::Error(error_JSON_RPC_InvalidParams(r#"missing field `x`"#)))
         );
         
         // test with valid params
         let params_value = match serde_json::to_value(&new_sample_params(10, 20)) {
-            Value::Object(object) => object, 
+            Ok(Value::Object(object)) => object, 
             _ => panic!("Not serialized into Object") 
         };
         let request = Request::new(1, "sample_fn".to_string(), params_value);

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -275,7 +275,7 @@ impl ResponseCompletable {
         self, params: RequestParams, method_handler: METHOD
     ) 
     where 
-        PARAMS : serde::Deserialize, 
+        for<'de> PARAMS : serde::Deserialize<'de>, 
         RET : serde::Serialize, 
         RET_ERROR : serde::Serialize,
         METHOD : FnOnce(PARAMS, MethodCompletable<RET, RET_ERROR>),
@@ -288,7 +288,7 @@ impl ResponseCompletable {
         self, params: RequestParams, sync_method_handler: METHOD
     ) 
     where 
-        PARAMS : serde::Deserialize, 
+        for<'de> PARAMS : serde::Deserialize<'de>, 
         RET : serde::Serialize, 
         RET_ERROR : serde::Serialize ,
         METHOD : FnOnce(PARAMS) -> MethodResult<RET, RET_ERROR>,
@@ -303,7 +303,7 @@ impl ResponseCompletable {
         self, params: RequestParams, method_handler: METHOD
     ) 
     where 
-        PARAMS : serde::Deserialize, 
+        for<'de> PARAMS : serde::Deserialize<'de>, 
         METHOD : FnOnce(PARAMS),
     {
         let mc = MethodCompletable::<(), ()>::new(self);
@@ -318,7 +318,7 @@ impl ResponseCompletable {
         self, params: RequestParams, sync_method_handler: METHOD
     ) 
     where 
-        PARAMS : serde::Deserialize, 
+        for<'de> PARAMS : serde::Deserialize<'de>, 
         METHOD : FnOnce(PARAMS),
     {
         self.handle_notification_with(params, |params| {
@@ -359,7 +359,7 @@ impl<
         method_fn: METHOD
     )
     where 
-        PARAMS : serde::Deserialize, 
+        for<'de> PARAMS : serde::Deserialize<'de>, 
         RET : serde::Serialize, 
         RET_ERROR : serde::Serialize,
         METHOD : FnOnce(PARAMS, Self),
@@ -421,11 +421,14 @@ impl Endpoint {
     
     /// Send a (non-notification) request
     pub fn send_request<
+        RET,
+        RET_ERROR,
         PARAMS : serde::Serialize, 
-        RET: serde::Deserialize, 
-        RET_ERROR : serde::Deserialize, 
     >(&mut self, method_name: &str, params: PARAMS) 
         -> GResult<RequestFuture<RET, RET_ERROR>> 
+    where
+        for<'de> RET: serde::Deserialize<'de>, 
+        for<'de> RET_ERROR : serde::Deserialize<'de>, 
     {
         let (completable, future) = futures::oneshot::<ResponseResult>();
         let future : futures::Oneshot<ResponseResult> = future;

--- a/src/jsonrpc_common.rs
+++ b/src/jsonrpc_common.rs
@@ -45,17 +45,17 @@ impl serde::Serialize for Id {
     }
 }
 
-impl serde::Deserialize for Id {
+impl<'de> serde::Deserialize<'de> for Id {
     fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
-        where DE: serde::Deserializer 
+        where DE: serde::Deserializer<'de> 
     {
-        deserializer.deserialize(IdDeserializeVisitor)
+        deserializer.deserialize_any(IdDeserializeVisitor)
     }
 }
 
 struct IdDeserializeVisitor;
 
-impl Visitor for IdDeserializeVisitor {
+impl<'de> Visitor<'de> for IdDeserializeVisitor {
     type Value = Id;
     
     fn visit_unit<E>(self) -> Result<Self::Value, E>
@@ -152,9 +152,9 @@ impl serde::Serialize for RequestError {
     }
 }
 
-impl serde::Deserialize for RequestError {
+impl<'de> serde::Deserialize<'de> for RequestError {
     fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
-        where DE: serde::Deserializer 
+        where DE: serde::Deserializer<'de> 
     {
         let mut helper = SerdeJsonDeserializerHelper::new(&deserializer);
         let value : Value = try!(Value::deserialize(deserializer));

--- a/src/jsonrpc_message.rs
+++ b/src/jsonrpc_message.rs
@@ -46,9 +46,9 @@ impl serde::Serialize for Message {
     }
 }
 
-impl serde::Deserialize for Message {
+impl<'de> serde::Deserialize<'de> for Message {
     fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
-        where DE: serde::Deserializer 
+        where DE: serde::Deserializer<'de> 
     {
         let mut helper = SerdeJsonDeserializerHelper::new(&deserializer);
         let value = try!(Value::deserialize(deserializer));

--- a/src/jsonrpc_message.rs
+++ b/src/jsonrpc_message.rs
@@ -36,7 +36,7 @@ impl From<Request> for Message {
 }
 
 impl serde::Serialize for Message {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: serde::Serializer
     {
         match *self {
@@ -47,11 +47,11 @@ impl serde::Serialize for Message {
 }
 
 impl serde::Deserialize for Message {
-    fn deserialize<DE>(deserializer: &mut DE) -> Result<Self, DE::Error>
+    fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
         where DE: serde::Deserializer 
     {
-        let mut helper = SerdeJsonDeserializerHelper(deserializer);
-        let value = try!(Value::deserialize(helper.0));
+        let mut helper = SerdeJsonDeserializerHelper::new(&deserializer);
+        let value = try!(Value::deserialize(deserializer));
         let json_obj = try!(helper.as_Object(value));
         
         if json_obj.contains_key("method") {

--- a/src/jsonrpc_response.rs
+++ b/src/jsonrpc_response.rs
@@ -83,9 +83,9 @@ impl serde::Serialize for Response {
     }
 }
 
-impl serde::Deserialize for Response {
+impl<'de> serde::Deserialize<'de> for Response {
     fn deserialize<DE>(deserializer: DE) -> Result<Self, DE::Error>
-        where DE: serde::Deserializer 
+        where DE: serde::Deserializer<'de> 
     {
         let mut helper = SerdeJsonDeserializerHelper::new(&deserializer);
         let value = try!(Value::deserialize(deserializer));

--- a/src/map_request_handler.rs
+++ b/src/map_request_handler.rs
@@ -32,13 +32,14 @@ impl MapRequestHandler {
          MapRequestHandler { method_handlers : HashMap::new() }
     }
     
-    pub fn add_notification<
-        PARAMS : serde::Deserialize + 'static,
-    >(
+    pub fn add_notification<PARAMS>(
         &mut self,
         method_name: &'static str, 
         method_fn: Box<Fn(PARAMS)>
-    ) {
+    )
+    where
+        for<'de> PARAMS : serde::Deserialize<'de> + 'static,
+    {
         let req_handler : Box<RpcMethodHandler> = new(move |params, completable| {
             completable.sync_handle_notification(params, &*method_fn);
         });
@@ -46,14 +47,17 @@ impl MapRequestHandler {
     }
     
     pub fn add_request<
-        PARAMS : serde::Deserialize + 'static, 
+        PARAMS,
         RET : serde::Serialize + 'static, 
         RET_ERROR : serde::Serialize + 'static
     >(
         &mut self,
         method_name: &'static str, 
         method_fn: Box<Fn(PARAMS) -> MethodResult<RET, RET_ERROR>>
-    ) {
+    )
+    where
+        for<'de> PARAMS : serde::Deserialize<'de> + 'static, 
+    {
         let req_handler : Box<RpcMethodHandler> = new(move |params, completable| {
             completable.sync_handle_request(params, &*method_fn);
         });

--- a/src/method_types.rs
+++ b/src/method_types.rs
@@ -41,14 +41,14 @@ where
     {
         match method_result {
             Ok(ret) => {
-                ResponseResult::Result(serde_json::to_value(&ret)) 
+                ResponseResult::Result(serde_json::to_value(&ret).unwrap()) 
             } 
             Err(error) => {
                 let code : u32 = error.code;
                 let request_error = RequestError { 
                     code : code as i64, // Safe convertion. TODO: use TryFrom when it's stable
                     message : error.message,
-                    data : Some(serde_json::to_value(&error.data)),
+                    data : Some(serde_json::to_value(&error.data).unwrap()),
                 };
                 ResponseResult::Error(request_error)
             }
@@ -118,18 +118,18 @@ impl<
         
         // Test Ok
         let params = new_sample_params(10, 20);
-        let response_result = ResponseResult::Result(serde_json::to_value(&params));
+        let response_result = ResponseResult::Result(serde_json::to_value(&params).unwrap());
         assert_eq!(
             RequestResult::<Point, ()>::from(response_result), 
             RequestResult::MethodResult(Ok(params.clone()))
         );
         
         // Test invalid MethodResult response 
-        let response_result = ResponseResult::Result(serde_json::to_value(&new_sample_params(10, 20)));
+        let response_result = ResponseResult::Result(serde_json::to_value(&new_sample_params(10, 20)).unwrap());
         assert_eq!(
             RequestResult::<String, ()>::from(response_result), 
             RequestResult::RequestError(error_JSON_RPC_InvalidResponse(
-                r#"invalid type: map at line 0 column 0"#))
+                r#"invalid type: map, expected a string"#))
         );
     }
     

--- a/src/method_types.rs
+++ b/src/method_types.rs
@@ -78,10 +78,10 @@ impl<RET, RET_ERROR> RequestResult<RET, RET_ERROR> {
     }
 }
 
-impl<
-    RET : serde::Deserialize, 
-    RET_ERROR : serde::Deserialize, 
-> From<ResponseResult> for RequestResult<RET, RET_ERROR> 
+impl<RET, RET_ERROR> From<ResponseResult> for RequestResult<RET, RET_ERROR> 
+where
+    for<'de> RET : serde::Deserialize<'de>, 
+    for<'de> RET_ERROR : serde::Deserialize<'de>, 
 {
     fn from(response_result : ResponseResult) -> Self 
     {

--- a/src/tests_sample_types.rs
+++ b/src/tests_sample_types.rs
@@ -3,7 +3,10 @@
 
 #![cfg(test)]
 
+use std::fmt;
+
 use serde;
+use serde::ser::SerializeStruct;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Point {
@@ -29,7 +32,7 @@ pub enum PointField {
 
 
 impl serde::Deserialize for PointField {
-    fn deserialize<D>(deserializer: &mut D) -> Result<PointField, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<PointField, D::Error>
         where D: serde::de::Deserializer
     {
         struct PointFieldVisitor;
@@ -37,7 +40,7 @@ impl serde::Deserialize for PointField {
         impl serde::de::Visitor for PointFieldVisitor {
             type Value = PointField;
 
-            fn visit_str<E>(&mut self, value: &str) -> Result<PointField, E>
+            fn visit_str<E>(self, value: &str) -> Result<PointField, E>
                 where E: serde::de::Error
             {
                 match value {
@@ -46,6 +49,11 @@ impl serde::Deserialize for PointField {
                     _ => Err(serde::de::Error::custom("expected x or y")),
                 }
             }
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
+            {
+                formatter.write_str("x or y")
+            }
         }
 
         deserializer.deserialize(PointFieldVisitor)
@@ -53,7 +61,7 @@ impl serde::Deserialize for PointField {
 }
 
 impl serde::Deserialize for Point {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Point, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Point, D::Error>
         where D: serde::de::Deserializer
     {
         static FIELDS: &'static [&'static str] = &["x", "y"];
@@ -66,7 +74,7 @@ struct PointVisitor;
 impl serde::de::Visitor for PointVisitor {
     type Value = Point;
 
-    fn visit_map<V>(&mut self, mut visitor: V) -> Result<Point, V::Error>
+    fn visit_map<V>(self, mut visitor: V) -> Result<Point, V::Error>
         where V: serde::de::MapVisitor
     {
         let mut x = None;
@@ -82,31 +90,34 @@ impl serde::de::Visitor for PointVisitor {
 
         let x = match x {
             Some(x) => x,
-            None => try!(visitor.missing_field("x")),
+            None => return Err(<V::Error as serde::de::Error>::missing_field("x")),
         };
 
         let y = match y {
             Some(y) => y,
-            None => try!(visitor.missing_field("y")),
+            None => return Err(<V::Error as serde::de::Error>::missing_field("y")),
         };
 
-        try!(visitor.end());
-
         Ok(Point{ x: x, y: y })
+    }
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
+    {
+        formatter.write_str("a point")
     }
 }
 
 
 impl serde::Serialize for Point {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: serde::Serializer,
     {
         let elem_count = 2;
         let mut state = try!(serializer.serialize_struct("Point", elem_count)); 
         {
-            try!(serializer.serialize_struct_elt(&mut state, "x", &self.x));
-            try!(serializer.serialize_struct_elt(&mut state, "y", &self.y));
+            try!(state.serialize_field("x", &self.x));
+            try!(state.serialize_field("y", &self.y));
         }
-        serializer.serialize_struct_end(state)
+        state.end()
     }
 }

--- a/src/tests_sample_types.rs
+++ b/src/tests_sample_types.rs
@@ -31,13 +31,13 @@ pub enum PointField {
 }
 
 
-impl serde::Deserialize for PointField {
+impl<'de> serde::Deserialize<'de> for PointField {
     fn deserialize<D>(deserializer: D) -> Result<PointField, D::Error>
-        where D: serde::de::Deserializer
+        where D: serde::de::Deserializer<'de>
     {
         struct PointFieldVisitor;
 
-        impl serde::de::Visitor for PointFieldVisitor {
+        impl<'de> serde::de::Visitor<'de> for PointFieldVisitor {
             type Value = PointField;
 
             fn visit_str<E>(self, value: &str) -> Result<PointField, E>
@@ -56,13 +56,13 @@ impl serde::Deserialize for PointField {
             }
         }
 
-        deserializer.deserialize(PointFieldVisitor)
+        deserializer.deserialize_any(PointFieldVisitor)
     }
 }
 
-impl serde::Deserialize for Point {
+impl<'de> serde::Deserialize<'de> for Point {
     fn deserialize<D>(deserializer: D) -> Result<Point, D::Error>
-        where D: serde::de::Deserializer
+        where D: serde::de::Deserializer<'de>
     {
         static FIELDS: &'static [&'static str] = &["x", "y"];
         deserializer.deserialize_struct("Point", FIELDS, PointVisitor)
@@ -71,19 +71,19 @@ impl serde::Deserialize for Point {
 
 struct PointVisitor;
 
-impl serde::de::Visitor for PointVisitor {
+impl<'de> serde::de::Visitor<'de> for PointVisitor {
     type Value = Point;
 
     fn visit_map<V>(self, mut visitor: V) -> Result<Point, V::Error>
-        where V: serde::de::MapVisitor
+        where V: serde::de::MapAccess<'de>
     {
         let mut x = None;
         let mut y = None;
 
         loop {
-            match try!(visitor.visit_key()) {
-                Some(PointField::X) => { x = Some(try!(visitor.visit_value())); }
-                Some(PointField::Y) => { y = Some(try!(visitor.visit_value())); }
+            match try!(visitor.next_key()) {
+                Some(PointField::X) => { x = Some(try!(visitor.next_value())); }
+                Some(PointField::Y) => { y = Some(try!(visitor.next_value())); }
                 None => { break; }
             }
         }

--- a/tests/tests_sample_types.rs
+++ b/tests/tests_sample_types.rs
@@ -24,13 +24,13 @@ pub enum PointField {
 }
 
 
-impl serde::Deserialize for PointField {
+impl<'de> serde::Deserialize<'de> for PointField {
     fn deserialize<D>(deserializer: D) -> Result<PointField, D::Error>
-        where D: serde::de::Deserializer
+        where D: serde::de::Deserializer<'de>
     {
         struct PointFieldVisitor;
 
-        impl serde::de::Visitor for PointFieldVisitor {
+        impl<'de> serde::de::Visitor<'de> for PointFieldVisitor {
             type Value = PointField;
 
             fn visit_str<E>(self, value: &str) -> Result<PointField, E>
@@ -49,13 +49,13 @@ impl serde::Deserialize for PointField {
             }
         }
 
-        deserializer.deserialize(PointFieldVisitor)
+        deserializer.deserialize_any(PointFieldVisitor)
     }
 }
 
-impl serde::Deserialize for Point {
+impl<'de> serde::Deserialize<'de> for Point {
     fn deserialize<D>(deserializer: D) -> Result<Point, D::Error>
-        where D: serde::de::Deserializer
+        where D: serde::de::Deserializer<'de>
     {
         static FIELDS: &'static [&'static str] = &["x", "y"];
         deserializer.deserialize_struct("Point", FIELDS, PointVisitor)
@@ -64,19 +64,19 @@ impl serde::Deserialize for Point {
 
 struct PointVisitor;
 
-impl serde::de::Visitor for PointVisitor {
+impl<'de> serde::de::Visitor<'de> for PointVisitor {
     type Value = Point;
 
     fn visit_map<V>(self, mut visitor: V) -> Result<Point, V::Error>
-        where V: serde::de::MapVisitor
+        where V: serde::de::MapAccess<'de>
     {
         let mut x = None;
         let mut y = None;
 
         loop {
-            match try!(visitor.visit_key()) {
-                Some(PointField::X) => { x = Some(try!(visitor.visit_value())); }
-                Some(PointField::Y) => { y = Some(try!(visitor.visit_value())); }
+            match try!(visitor.next_key()) {
+                Some(PointField::X) => { x = Some(try!(visitor.next_value())); }
+                Some(PointField::Y) => { y = Some(try!(visitor.next_value())); }
                 None => { break; }
             }
         }


### PR DESCRIPTION
Upgrade rustdt-json_rpc to the Serde 1.0.0. Using a stable version of Serde will let people more easily use rustdt-json_rpc.

Serde introduced many breaking changes between versions 0.8.0 and 1.0.0:

* https://github.com/serde-rs/serde/releases/tag/v0.9.0
* https://github.com/serde-rs/json/releases/tag/v0.9.0
* https://github.com/serde-rs/serde/releases/tag/v1.0.0
* https://github.com/serde-rs/json/releases/tag/v1.0.0

These commits address issue #1.

Note to maintainers: I strongly prefer *rebasing* or *merging* (and not squashing) to preserve history.